### PR TITLE
제품 디테일 Message type을 RichMedia에서 Text로 변경, 제품 리스트와 제품 디테일에 키보드 추가

### DIFF
--- a/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/client/ProductApiClient.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/client/ProductApiClient.java
@@ -11,8 +11,6 @@ import com.sharetreats01.viber_chatbot.infra.sharetreats.product.dto.request.Get
 public interface ProductApiClient {
     AvailablePaymentsResponse getPaymentList(Long productId);
     BrandListResponse getBrandList(GetBrandRequest request);
-
-    ProductListResponse getProductsList(String brandName);
-
+    ProductListResponse getProductsList(Long brandId);
     ProductDetailResponse getProductDetail(Long productId);
 }

--- a/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/client/ProductApiClientImpl.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/client/ProductApiClientImpl.java
@@ -33,12 +33,12 @@ public class ProductApiClientImpl implements ProductApiClient {
     }
 
     @Override
-    public ProductListResponse getProductsList(String request) {
-        log.info("GetProductListRequest {}", request);
+    public ProductListResponse getProductsList(Long brandId) {
+        log.info("GetProductListRequest {}", brandId);
         WebClient.ResponseSpec responseSpec = productApiClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(productApiProperties.getProductListUri())
-                        .queryParam("partners", request)
+                        .queryParam("brandId", brandId)
                         .build()
                 )
                 .accept(MediaType.APPLICATION_JSON)
@@ -61,7 +61,6 @@ public class ProductApiClientImpl implements ProductApiClient {
 
     @Override
     public ProductDetailResponse getProductDetail(Long productId) {
-        log.info("ProductDetailResponse {}", productId);
         WebClient.ResponseSpec responseSpec = productApiClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(productApiProperties.getProductDetailUri())

--- a/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/dto/response/ProductDetailResponse.java
@@ -27,6 +27,9 @@ public class ProductDetailResponse {
     @JsonProperty("origin_price")
     private String originPrice;
 
+    @JsonProperty("discount_price")
+    private String discountPrice;
+
     @JsonProperty("description")
     private String description;
 

--- a/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/service/ProductService.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/service/ProductService.java
@@ -24,8 +24,8 @@ public class ProductService {
         return productApiClient.getBrandList(request);
     }
 
-    public ProductListResponse getProducts(String brandName) {
-        return productApiClient.getProductsList(brandName);
+    public ProductListResponse getProducts(Long brandId) {
+        return productApiClient.getProductsList(brandId);
     }
 
     public ProductDetailResponse getProductDetail(Long productId) {

--- a/src/main/java/com/sharetreats01/viber_chatbot/infra/viber/service/ProductDetailMessageService.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/infra/viber/service/ProductDetailMessageService.java
@@ -1,12 +1,56 @@
 package com.sharetreats01.viber_chatbot.infra.viber.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sharetreats01.viber_chatbot.enums.ActionType;
+import com.sharetreats01.viber_chatbot.enums.TextHAlign;
+import com.sharetreats01.viber_chatbot.enums.TextSize;
+import com.sharetreats01.viber_chatbot.enums.TextVAlign;
 import com.sharetreats01.viber_chatbot.infra.sharetreats.product.dto.response.ProductDetailResponse;
+import com.sharetreats01.viber_chatbot.infra.viber.dto.request.property.Keyboard;
+import com.sharetreats01.viber_chatbot.util.KeyboardConstants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.StringJoiner;
 
+@Slf4j
 @Service
 public class ProductDetailMessageService {
+    public String getProductDetailKeyboard(ProductDetailResponse productDetail) {
+        Keyboard.Button[] buttons = new Keyboard.Button[2];
+
+        buttons[0] = Keyboard.Button.builder()
+                .columns(KeyboardConstants.PRODUCT_DETAIL_BUTTONS_COLUMNS)
+                .rows(KeyboardConstants.PRODUCT_DETAIL_FIRST_BUTTONS_ROWS)
+                .bgColor(KeyboardConstants.BUTTON_BG_COLOR)
+                .actionType(ActionType.OPEN_URL)
+                .actionBody(productDetail.getParticipationUrl())
+                .text(KeyboardConstants.SEE_PARTICIPATING_STORE)
+                .textSize(TextSize.LARGE)
+                .textVAlign(TextVAlign.MIDDLE)
+                .textHAlign(TextHAlign.CENTER)
+                .build();
+
+        buttons[1] = Keyboard.Button.builder()
+                .columns(KeyboardConstants.PRODUCT_DETAIL_BUTTONS_COLUMNS)
+                .rows(KeyboardConstants.PRODUCT_DETAIL_SECOND_BUTTONS_ROWS)
+                .bgColor(KeyboardConstants.BUTTON_BG_COLOR)
+                .actionType(ActionType.REPLY)
+                .actionBody(KeyboardConstants.SEND_TREAT_ACTIONBODY + productDetail.getProductId())
+                .text(KeyboardConstants.SEND_TREAT)
+                .textSize(TextSize.LARGE)
+                .textVAlign(TextVAlign.MIDDLE)
+                .textHAlign(TextHAlign.CENTER)
+                .build();
+
+        Keyboard keyboard = Keyboard.builder()
+                .buttons(buttons)
+                .build();
+
+        return convertToJson(keyboard);
+    }
+
     public String getProductDetailText(ProductDetailResponse productDetail) {
         String newline = "\n";
 
@@ -18,5 +62,16 @@ public class ProductDetailMessageService {
                 .add(productDetail.getDescription());
 
         return text.toString();
+    }
+
+    private String convertToJson(Object keyboard) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            return objectMapper.writeValueAsString(keyboard);
+        } catch (JsonProcessingException e) {
+            log.error("Error occurred while converting to JSON: {}", e.getMessage());
+            throw new RuntimeException("Error while processing Object JSON: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/sharetreats01/viber_chatbot/infra/viber/service/ProductDetailMessageService.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/infra/viber/service/ProductDetailMessageService.java
@@ -1,0 +1,22 @@
+package com.sharetreats01.viber_chatbot.infra.viber.service;
+
+import com.sharetreats01.viber_chatbot.infra.sharetreats.product.dto.response.ProductDetailResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.StringJoiner;
+
+@Service
+public class ProductDetailMessageService {
+    public String getProductDetailText(ProductDetailResponse productDetail) {
+        String newline = "\n";
+
+        StringJoiner text = new StringJoiner(newline);
+        text.add(productDetail.getBrandName())
+                .add(productDetail.getProductName())
+                .add(productDetail.getOriginPrice() + " -> "
+                        + productDetail.getDiscountPrice() + newline)
+                .add(productDetail.getDescription());
+
+        return text.toString();
+    }
+}

--- a/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductDetailMessageCreator.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductDetailMessageCreator.java
@@ -40,8 +40,14 @@ public class ProductDetailMessageCreator extends AbstractMessageCreator {
         ProductDetailResponse productDetail = productService.getProductDetail(productId);
 
         String text = productDetailMessageService.getProductDetailText(productDetail);
+        String keyboard = productDetailMessageService.getProductDetailKeyboard(productDetail);
 
-        return new SendTextMessageRequest(receiver, chatbotProperties.getBotName(),
-                chatbotProperties.getBotAvatar(), 7, text, trackingData);
+        SendTextMessageRequest messageRequest =
+                new SendTextMessageRequest(receiver, chatbotProperties.getBotName(),
+                        chatbotProperties.getBotAvatar(), 7, text, trackingData);
+
+        messageRequest.setKeyboard(keyboard);
+
+        return messageRequest;
     }
 }

--- a/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductDetailMessageCreator.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductDetailMessageCreator.java
@@ -4,9 +4,9 @@ import com.sharetreats01.viber_chatbot.dto.callback.request.MessageRequest;
 import com.sharetreats01.viber_chatbot.infra.sharetreats.product.dto.response.ProductDetailResponse;
 import com.sharetreats01.viber_chatbot.infra.sharetreats.product.service.ProductService;
 import com.sharetreats01.viber_chatbot.infra.viber.dto.request.SendMessageRequest;
-import com.sharetreats01.viber_chatbot.infra.viber.dto.request.SendProductRichMediaMessageRequest;
-import com.sharetreats01.viber_chatbot.infra.viber.dto.request.property.Keyboard;
-import com.sharetreats01.viber_chatbot.infra.viber.service.ProductRichMediaService;
+import com.sharetreats01.viber_chatbot.infra.viber.dto.request.SendTextMessageRequest;
+import com.sharetreats01.viber_chatbot.infra.viber.service.ProductDetailMessageService;
+import com.sharetreats01.viber_chatbot.properties.ChatbotProperties;
 import com.sharetreats01.viber_chatbot.util.TrackingDataUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,15 +14,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class ProductDetailMessageCreator extends AbstractMessageCreator {
-//    private final RichMediaService richMediaService;
     private final ProductService productService;
-    private final ProductRichMediaService productRichMediaService;
+    private final ChatbotProperties chatbotProperties;
+    private final ProductDetailMessageService productDetailMessageService;
 
-    public ProductDetailMessageCreator(TrackingDataUtils trackingDataUtils, ProductRichMediaService productRichMediaService,
-                                       ProductService productService) {
+    public ProductDetailMessageCreator(TrackingDataUtils trackingDataUtils, ProductService productService,
+                                       ChatbotProperties chatbotProperties, ProductDetailMessageService productDetailMessageService) {
         super(trackingDataUtils);
-        this.productRichMediaService = productRichMediaService;
         this.productService = productService;
+        this.chatbotProperties = chatbotProperties;
+        this.productDetailMessageService = productDetailMessageService;
     }
 
     @Override
@@ -37,9 +38,10 @@ public class ProductDetailMessageCreator extends AbstractMessageCreator {
 
         Long productId = Long.parseLong(request.getMessage().getText());
         ProductDetailResponse productDetail = productService.getProductDetail(productId);
-        Keyboard richMedia = productRichMediaService.getProductDetailRichMedia(productDetail);
 
-       return new SendProductRichMediaMessageRequest(receiver, 7, richMedia, trackingData);
+        String text = productDetailMessageService.getProductDetailText(productDetail);
 
+        return new SendTextMessageRequest(receiver, chatbotProperties.getBotName(),
+                chatbotProperties.getBotAvatar(), 7, text, trackingData);
     }
 }

--- a/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductsMessageCreator.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductsMessageCreator.java
@@ -37,8 +37,8 @@ public class ProductsMessageCreator extends AbstractMessageCreator {
         String input = request.getMessage().getText();
         String trackingData = createTrackingData(request.getMessage().getTrackingData(), input);
 
-        String brandName = request.getMessage().getText();
-        ProductListResponse products = productService.getProducts(brandName);
+        Long brandId = Long.valueOf(request.getMessage().getText());
+        ProductListResponse products = productService.getProducts(brandId);
         Keyboard richMedia = productRichMediaService.getProductsRichMedia(products);
 
         SendProductRichMediaMessageRequest messageRequest =

--- a/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductsMessageCreator.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/support/creator/ProductsMessageCreator.java
@@ -6,6 +6,7 @@ import com.sharetreats01.viber_chatbot.infra.sharetreats.product.service.Product
 import com.sharetreats01.viber_chatbot.infra.viber.dto.request.SendMessageRequest;
 import com.sharetreats01.viber_chatbot.infra.viber.dto.request.SendProductRichMediaMessageRequest;
 import com.sharetreats01.viber_chatbot.infra.viber.dto.request.property.Keyboard;
+import com.sharetreats01.viber_chatbot.infra.viber.service.KeyBoardService;
 import com.sharetreats01.viber_chatbot.infra.viber.service.ProductRichMediaService;
 import com.sharetreats01.viber_chatbot.util.TrackingDataUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -14,15 +15,21 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class ProductsMessageCreator extends AbstractMessageCreator {
-    //    private final RichMediaService richMediaService;
-    private final ProductService productService;
     private final ProductRichMediaService productRichMediaService;
+    private final KeyBoardService keyBoardService;
+    private final ProductService productService;
 
     public ProductsMessageCreator(TrackingDataUtils trackingDataUtils, ProductRichMediaService productRichMediaService,
-                                  ProductService productService) {
+                                  KeyBoardService keyBoardService, ProductService productService) {
         super(trackingDataUtils);
         this.productRichMediaService = productRichMediaService;
+        this.keyBoardService = keyBoardService;
         this.productService = productService;
+    }
+
+    @Override
+    protected String createTrackingData(String trackingData, String input) {
+        return trackingDataUtils.updateState(trackingData, input);
     }
 
     public SendMessageRequest createMessageRequest(MessageRequest request) {
@@ -34,11 +41,11 @@ public class ProductsMessageCreator extends AbstractMessageCreator {
         ProductListResponse products = productService.getProducts(brandName);
         Keyboard richMedia = productRichMediaService.getProductsRichMedia(products);
 
-        return new SendProductRichMediaMessageRequest(receiver, 7, richMedia, trackingData);
-    }
+        SendProductRichMediaMessageRequest messageRequest =
+                new SendProductRichMediaMessageRequest(receiver, 7, richMedia, trackingData);
 
-    @Override
-    protected String createTrackingData(String trackingData, String input) {
-        return trackingDataUtils.updateState(trackingData, input);
+        messageRequest.setKeyboard(keyBoardService.findBrands());
+
+        return messageRequest;
     }
 }

--- a/src/main/java/com/sharetreats01/viber_chatbot/util/KeyboardConstants.java
+++ b/src/main/java/com/sharetreats01/viber_chatbot/util/KeyboardConstants.java
@@ -5,6 +5,8 @@ public class KeyboardConstants {
     public static final String BUTTON_BG_COLOR = "#87CEEB";
     public static final String VIEW_MORE = "<font color=#ffffff>View more</font>";
     public static final String SEND_TREAT = "<font color=#ffffff>Send Treat</font>";
+    public static final String SEE_PARTICIPATING_STORE = "see participating stores";
+    public static final String SEND_TREAT_ACTIONBODY = "TREAT_";
     public static final int BUTTONS_GROUP_COLUMNS_MAX = 6;
     public static final int BUTTONS_GROUP_ROWS_MAX = 7;
     public static final int PRODUCT_BUTTONS_COLUMNS = 6;
@@ -13,7 +15,7 @@ public class KeyboardConstants {
     public static final int PRODUCT_THIRD_BUTTONS_ROWS = 1;
     public static final int PRODUCT_FOURTH_BUTTONS_ROWS = 1;
     public static final int PRODUCT_DETAIL_BUTTONS_COLUMNS = 6;
-    public static final int PRODUCT_DETAIL_FIRST_BUTTONS_ROWS = 6;
+    public static final int PRODUCT_DETAIL_FIRST_BUTTONS_ROWS = 1;
     public static final int PRODUCT_DETAIL_SECOND_BUTTONS_ROWS = 1;
     public static final int FRAME_CORNER_RADIUS = 10;
 }

--- a/src/test/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/client/ProductApiClientTest.java
+++ b/src/test/java/com/sharetreats01/viber_chatbot/infra/sharetreats/product/client/ProductApiClientTest.java
@@ -54,8 +54,8 @@ public class ProductApiClientTest {
     @Test
     @DisplayName("Mock Server에서 제품 리스트 받기")
     public void getProductList() {
-        String brandName1 = "McDonald's";
-        String brandName2 = "KFC";
+        Long brandId1 = 1L;
+        Long brandId2 = 2L;
 
         List<Product> productList1 = new ArrayList<>();
         productList1.add(new Product(1L, "Cheeseburger Solo", 1L,
@@ -79,21 +79,21 @@ public class ProductApiClientTest {
                 .build();
 
 
-        when(productApiClient.getProductsList(brandName1)).thenReturn(expectedProductList1);
-        when(productApiClient.getProductsList(brandName2)).thenReturn(expectedProductList2);
+        when(productApiClient.getProductsList(brandId1)).thenReturn(expectedProductList1);
+        when(productApiClient.getProductsList(brandId2)).thenReturn(expectedProductList2);
 
-        ProductListResponse actualProductList1 = productApiClient.getProductsList(brandName1);
-        ProductListResponse actualProductList2 = productApiClient.getProductsList(brandName2);
+        ProductListResponse actualProductList1 = productApiClient.getProductsList(brandId1);
+        ProductListResponse actualProductList2 = productApiClient.getProductsList(brandId2);
 
 
         assertEquals(expectedProductList1.getProducts().get(0).getBrandName(),
                 actualProductList1.getProducts().get(0).getBrandName());
-        assertEquals(expectedProductList1.getProducts().get(0).getId(),
-                actualProductList1.getProducts().get(0).getId());
+        assertEquals(expectedProductList1.getProducts().get(1).getId(),
+                actualProductList1.getProducts().get(1).getId());
 
         assertEquals(expectedProductList2.getProducts().get(0).getBrandName(),
                 actualProductList2.getProducts().get(0).getBrandName());
-        assertEquals(expectedProductList2.getProducts().get(0).getId(),
-                actualProductList2.getProducts().get(0).getId());
+        assertEquals(expectedProductList2.getProducts().get(1).getId(),
+                actualProductList2.getProducts().get(1).getId());
     }
 }


### PR DESCRIPTION
**1.  feat: ProductDetailResponse 클래스에 discountPrice 추가**
-  "ProductDetailResponse" 클래스에 "discountPrice" 필드가 누락되어 있어서 추가
<br>

**2. feat: 제품 리스트 메시지 전송할 때 브랜드 키보드 추가**
<br>

**3. fix: 'partners' 쿼리 파라미터를 'brandId'로 변경**
-  'partners' 쿼리 파라미터의 이름을 'brandId'로 변경
<br>

**4. fix: 제품 디테일 Message type을 RichMedia에서 Text로 변경**
- 기능 수정을 위해 "제품 디테일" 메시지 타입을 "RichMedia"에서 "Text"로 변경
<br>

**5.  test: brandName에서 brandId로 변경**
-  'partners' 쿼리 파라미터를 'brandId'로 변경함에 따라서 테스트를 위해  String brandName에서 Long brandId로 변경
<br>

**6. feat: 제품 디테일 메시지 전송할 때 키보드 추가**